### PR TITLE
Error handling for missing modifiers on linked objects

### DIFF
--- a/modules/operators/modifier_apply.py
+++ b/modules/operators/modifier_apply.py
@@ -220,9 +220,12 @@ class ApplyModifier:
                               if ob.data and ob.data.name == data_name]
 
         for ob in obs_with_same_data:
-            mod = ob.modifiers[modifier_name]
-            if mod.type == modifier_type:
-                ob.modifiers.remove(mod)
+            try:
+                mod = ob.modifiers[modifier_name]
+                if mod.type == modifier_type:
+                    ob.modifiers.remove(mod)
+            except:
+                pass
 
     def curve_modifier_apply_report(self, modifier_type):
         curve_deform_mods = [mod[2] for mod in CURVE_SURFACE_TEXT_DEFORM_NAMES_ICONS_TYPES]


### PR DESCRIPTION
Wrapped modifier removal logic in a try block as not all linked objects have the same modifiers. For me, only the "original" has the modifier to apply on all linked instances, and the current logic fails with an exception when it tries to get ob.modifiers[modifier_name], as the modifier is not there.